### PR TITLE
feat: [#474] goravel/minio should use the docker module of framework

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -2,11 +2,14 @@ package sqlserver
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	contractsdocker "github.com/goravel/framework/contracts/testing/docker"
+	supportdocker "github.com/goravel/framework/support/docker"
 	testingdocker "github.com/goravel/framework/testing/docker"
 	"github.com/goravel/sqlserver/contracts"
+	"github.com/spf13/cast"
 	"gorm.io/driver/sqlserver"
 	gormio "gorm.io/gorm"
 )
@@ -47,7 +50,7 @@ func (r *Docker) Build() error {
 
 	config := r.imageDriver.Config()
 	r.databaseConfig.ContainerID = config.ContainerID
-	r.databaseConfig.Port = config.ExposedPorts[r.databaseConfig.Port]
+	r.databaseConfig.Port = cast.ToInt(supportdocker.ExposedPort(config.ExposedPorts, strconv.Itoa(r.databaseConfig.Port)))
 
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.23.4
 
 require (
 	github.com/Masterminds/squirrel v1.5.4
-	github.com/goravel/framework v1.15.2-0.20250609081116-6ecd2b376447
+	github.com/goravel/framework v1.15.2-0.20250609104359-90480ea9b358
 	github.com/spf13/cast v1.9.2
 	github.com/stretchr/testify v1.10.0
 	gorm.io/driver/sqlserver v1.5.4

--- a/go.sum
+++ b/go.sum
@@ -165,8 +165,8 @@ github.com/gookit/validate v1.5.5 h1:jzMrwAYy9tbQa0mH8YFnv3C3JQR/0N4pRTsYiySwRJM
 github.com/gookit/validate v1.5.5/go.mod h1:p9sRPfpvYB4vXICBpEPzv8FoAky+XhUOhWQghgmmat4=
 github.com/goravel/file-rotatelogs/v2 v2.4.2 h1:g68AzbePXcm0V2CpUMc9j4qVzcDn7+7aoWSjZ51C0m4=
 github.com/goravel/file-rotatelogs/v2 v2.4.2/go.mod h1:23VuSW8cBS4ax5cmbV+5AaiLpq25b8UJ96IhbAkdo8I=
-github.com/goravel/framework v1.15.2-0.20250609081116-6ecd2b376447 h1:cDj3AvYAWnmdE96suMIP7m0BBkLPwtRyDS67GPvkq/w=
-github.com/goravel/framework v1.15.2-0.20250609081116-6ecd2b376447/go.mod h1:rMwbA0b1HX/2NUaPGxejp9AG4kfBfqy7D5gdRGy2clo=
+github.com/goravel/framework v1.15.2-0.20250609104359-90480ea9b358 h1:itDiQBc39teENLiTK7hQsKp7YGKjDvJ2KHlxMfyDeOg=
+github.com/goravel/framework v1.15.2-0.20250609104359-90480ea9b358/go.mod h1:rMwbA0b1HX/2NUaPGxejp9AG4kfBfqy7D5gdRGy2clo=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=


### PR DESCRIPTION
## 📑 Description

Closes https://github.com/goravel/goravel/issues/474

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

This pull request introduces updates to the `sqlserver` package, focusing on dependency management and enhancements to the `docker.go` file. The most important changes involve adding new imports, updating the `Build` method for better port handling, and upgrading a framework dependency in `go.mod`.

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
