### PR TITLE
feat: add UUID and ULID type support for SQL Server grammar

### DIFF
--- a/grammar.go
+++ b/grammar.go
@@ -671,6 +671,14 @@ func (r *Grammar) TypeTinyText(_ driver.ColumnDefinition) string {
 	return "nvarchar(255)"
 }
 
+func (r *Grammar) TypeUuid(_ driver.ColumnDefinition) string {
+	return "uniqueidentifier"
+}
+
+func (r *Grammar) TypeUlid(_ driver.ColumnDefinition) string {
+	return "nchar(26)"
+}
+
 func (r *Grammar) compileDecimalCastExpr(value float64) (string, string) {
 	param := strconv.FormatFloat(value, 'f', -1, 64)
 	parts := strings.Split(param, ".")

--- a/grammar.go
+++ b/grammar.go
@@ -675,10 +675,6 @@ func (r *Grammar) TypeUuid(_ driver.ColumnDefinition) string {
 	return "uniqueidentifier"
 }
 
-func (r *Grammar) TypeUlid(_ driver.ColumnDefinition) string {
-	return "nchar(26)"
-}
-
 func (r *Grammar) compileDecimalCastExpr(value float64) (string, string) {
 	param := strconv.FormatFloat(value, 'f', -1, 64)
 	parts := strings.Split(param, ".")

--- a/grammar_test.go
+++ b/grammar_test.go
@@ -724,6 +724,18 @@ func (s *GrammarSuite) TestTypeTimestampTz() {
 	s.Equal("datetimeoffset", s.grammar.TypeTimestampTz(mockColumn))
 }
 
+func (s *GrammarSuite) TestTypeUuid() {
+	mockColumn := mocksdriver.NewColumnDefinition(s.T())
+
+	s.Equal("uniqueidentifier", s.grammar.TypeUuid(mockColumn))
+}
+
+func (s *GrammarSuite) TestTypeUlid() {
+	mockColumn := mocksdriver.NewColumnDefinition(s.T())
+
+	s.Equal("nchar(26)", s.grammar.TypeUlid(mockColumn))
+}
+
 func TestParseSchemaAndTable(t *testing.T) {
 	tests := []struct {
 		reference      string

--- a/grammar_test.go
+++ b/grammar_test.go
@@ -730,12 +730,6 @@ func (s *GrammarSuite) TestTypeUuid() {
 	s.Equal("uniqueidentifier", s.grammar.TypeUuid(mockColumn))
 }
 
-func (s *GrammarSuite) TestTypeUlid() {
-	mockColumn := mocksdriver.NewColumnDefinition(s.T())
-
-	s.Equal("nchar(26)", s.grammar.TypeUlid(mockColumn))
-}
-
 func TestParseSchemaAndTable(t *testing.T) {
 	tests := []struct {
 		reference      string


### PR DESCRIPTION
## 📑 Description

https://github.com/goravel/framework/pull/1114

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->
This pull request introduces support for two new data types, `UUID` and `ULID`, in the `Grammar` class. Corresponding test cases have also been added to ensure the correct behavior of these new methods.

### Additions to `Grammar` class:

* Added `TypeUuid` method to map `UUID` to the database type `uniqueidentifier`. (`grammar.go`, [grammar.goR674-R681](diffhunk://#diff-077173eed4fe6bc9d3ea50005c9ad034d45bb24372cdc6aea57e61aab9f3afacR674-R681))
* Added `TypeUlid` method to map `ULID` to the database type `nchar(26)`. (`grammar.go`, [grammar.goR674-R681](diffhunk://#diff-077173eed4fe6bc9d3ea50005c9ad034d45bb24372cdc6aea57e61aab9f3afacR674-R681))

### New test cases:

* Added `TestTypeUuid` to validate that `TypeUuid` correctly returns `uniqueidentifier`. (`grammar_test.go`, [grammar_test.goR727-R738](diffhunk://#diff-8bec341f2415d1a975ac79feb01a945838efe972da6b9253a259af476c76608dR727-R738))
* Added `TestTypeUlid` to validate that `TypeUlid` correctly returns `nchar(26)`. (`grammar_test.go`, [grammar_test.goR727-R738](diffhunk://#diff-8bec341f2415d1a975ac79feb01a945838efe972da6b9253a259af476c76608dR727-R738))

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
